### PR TITLE
Call pytest programmatically

### DIFF
--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -1,7 +1,7 @@
 import os
 from playwright.sync_api import sync_playwright
 from agent.setup import TEST_DIR
-from agent.utils import strip_code_fences
+from agent.utils import run_pytest_and_capture_output, strip_code_fences
 from agent.logging import logger, console
 from rich.panel import Panel
 from typing import TypedDict
@@ -63,7 +63,7 @@ def write_code_to_file(**kwargs: TWriteCodeToFile):
 
 def run_tests():
     logger.info("Running tests")
-    output = os.popen(f"cd {TEST_DIR} && pytest").read()
+    output = run_pytest_and_capture_output(TEST_DIR)
     console.print("\n")
     console.print(Panel(output, title="Test Output", highlight=True, padding=(1, 1)))
     console.print("\n")

--- a/src/agent/utils.py
+++ b/src/agent/utils.py
@@ -1,2 +1,21 @@
+import io
+import pytest
+from pathlib import Path
+from contextlib import redirect_stdout
+
+
 def strip_code_fences(code):
     return code.replace("```python", "").replace("```", "")
+
+
+def run_pytest_and_capture_output(test_dir: Path) -> str:
+    # Create a StringIO buffer to capture the output
+    buffer = io.StringIO()
+    # Redirect the stdout to the buffer
+    with redirect_stdout(buffer):
+        pytest.main(["-x", str(test_dir)])
+    # Get the content of the buffer
+    output = buffer.getvalue()
+    # Close the buffer
+    buffer.close()
+    return output

--- a/uv.lock
+++ b/uv.lock
@@ -32,7 +32,7 @@ wheels = [
 
 [[package]]
 name = "automators-agent"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
This pull request introduces a new utility function to capture pytest output and refactors the existing code to use this function. The most significant changes include importing the new utility function, modifying the test-running logic, and adding the new function.

Refactoring and new utility function:

* [`src/agent/tools.py`](diffhunk://#diff-e0b516691ff100add4484a056628cf60d1ad3e562e1540f1a63a67d44cf3efb6L4-R4): Imported `run_pytest_and_capture_output` from `agent.utils` and replaced the existing test-running logic with a call to this new function in `run_tests`. [[1]](diffhunk://#diff-e0b516691ff100add4484a056628cf60d1ad3e562e1540f1a63a67d44cf3efb6L4-R4) [[2]](diffhunk://#diff-e0b516691ff100add4484a056628cf60d1ad3e562e1540f1a63a67d44cf3efb6L66-R66)
* [`src/agent/utils.py`](diffhunk://#diff-d296951d796f0ca48d77aa4eca27e060bca2660129539ab12bddc66a770b249aR1-R21): Added the `run_pytest_and_capture_output` function to capture pytest output using `redirect_stdout` and `StringIO`.