### PR TITLE
Run subprocess commands in user shell

### DIFF
--- a/src/agent/scaffold.py
+++ b/src/agent/scaffold.py
@@ -18,7 +18,7 @@ def check_for_node():
     """Checks if node.js in installed on the system"""
     try:
         logger.info("Checking that Node.js is installed.")
-        version = subprocess.check_output(["node", "-v"])
+        version = subprocess.check_output(["node", "--version"], shell=True)
         if version:
             logger.info(f"found node version: {version.decode().strip()}")
 
@@ -34,7 +34,7 @@ def check_for_npm():
     """Checks if npm is installed on the system"""
     try:
         logger.info("Checking that npm is installed.")
-        version = subprocess.check_output(["npm", "-v"])
+        version = subprocess.check_output(["npm", "--version"], shell=True)
         if version:
             logger.info(f"found npm version: {version.decode().strip()}")
 
@@ -49,7 +49,7 @@ def check_for_playwright():
     """Checks if playwright is installed on the system"""
     try:
         logger.info("Checking that Playwright is installed.")
-        version = subprocess.check_output(["playwright", "--version"])
+        version = subprocess.check_output(["playwright", "--version"], shell=True)
         if version:
             logger.info(f"found playwright version: {version.decode().strip()}")
 
@@ -64,7 +64,7 @@ def check_for_cypress():
     """Checks if cypress is installed on the system"""
     try:
         logger.info("Checking that Cypress is installed.")
-        version = subprocess.check_output(["cypress", "--version"])
+        version = subprocess.check_output(["cypress", "--version"], shell=True)
         if version:
             logger.info(f"found cypress version: {version.decode().strip()}")
 
@@ -123,12 +123,14 @@ def scaffold_playwright(
     subprocess.run(
         cmd,
         cwd=test_dir,
+        shell=True,
     )
 
     logger.info("Adding dev dependencies.")
     subprocess.run(
         ["npm", "install", "uuid", "--save-dev"],
         cwd=test_dir,
+        shell=True,
     )
 
 
@@ -142,6 +144,7 @@ def check_for_playwright_browsers(
             ["playwright", "install", "chromium"],
             check=True,
             cwd=test_dir,
+            shell=True,
         )
     except subprocess.CalledProcessError:
         return False
@@ -158,6 +161,7 @@ def check_for_cypress_installation(test_dir: Path):
             ["npx", "--yes", "cypress", "install"],
             check=True,
             cwd=test_dir,
+            shell=True,
         )
     except subprocess.CalledProcessError:
         return False
@@ -321,4 +325,5 @@ module.exports = defineConfig({
     subprocess.run(
         ["npm", "install"],
         cwd=test_dir,
+        shell=True,
     )

--- a/src/agent/utils.py
+++ b/src/agent/utils.py
@@ -125,7 +125,13 @@ def check_for_screenshots():
     if trace_files:
         for trace_file in trace_files:
             # extract the contents of the zip file
-            subprocess.run(["unzip", str(trace_file), "-d", str(trace_file.parent)])
+            try:
+                subprocess.run(
+                    ["unzip", str(trace_file), "-d", str(trace_file.parent)],
+                    shell=True,
+                )
+            except Exception as e:
+                logger.error(f"Error extracting trace file: {e}")
 
     # check for video files
     video_files = list(test_dir.glob("**/*.webm"))


### PR DESCRIPTION
This pull request includes several changes to the `src/agent/scaffold.py` and `src/agent/utils.py` files to ensure the `shell=True` parameter is used in subprocess calls and to improve error handling. The most important changes include updating subprocess calls to use `shell=True` and adding error handling for the `check_for_screenshots` function.

### Subprocess Call Updates:
* [`src/agent/scaffold.py`](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eL21-R21): Updated subprocess calls in `check_for_node`, `check_for_npm`, `check_for_playwright`, and `check_for_cypress` to use `shell=True`. [[1]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eL21-R21) [[2]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eL37-R37) [[3]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eL52-R52) [[4]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eL67-R67)
* [`src/agent/scaffold.py`](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eR126-R133): Added `shell=True` to subprocess calls in `scaffold_playwright`, `check_for_playwright_browsers`, `check_for_cypress_installation`, and `scaffold_cypress`. [[1]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eR126-R133) [[2]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eR147) [[3]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eR164) [[4]](diffhunk://#diff-075d64a205a9fc7fd42b43c83b39e1b2ab9ca9f572eff73c50c8ba4b35780e3eR328)

### Error Handling Improvements:
* [`src/agent/utils.py`](diffhunk://#diff-d296951d796f0ca48d77aa4eca27e060bca2660129539ab12bddc66a770b249aL128-R134): Added error handling to the `check_for_screenshots` function to log errors when extracting trace files.