### PR TITLE
Add tools to list dirs and read file content

### DIFF
--- a/src/agent/tools.py
+++ b/src/agent/tools.py
@@ -177,6 +177,41 @@ def get_user_input(**kwargs: TGetUserInput) -> str:
     return response
 
 
+class TListFiles(TypedDict):
+    dir: str
+
+
+def list_files_in_dir(**kwargs: TListFiles) -> str:
+    dir = kwargs.get("dir", ".")
+
+    if not dir:
+        return "No directory provided to list files in."
+
+    # check if the directory exists
+    if not os.path.exists(dir):
+        return f"Directory {dir} does not exist."
+
+    files = os.listdir(dir)
+    return files
+
+
+class TReadFileContents(TypedDict):
+    path: str
+
+
+def read_file_contents(**kwargs: TReadFileContents) -> str:
+    path = kwargs.get("path", None)
+
+    if not path:
+        return "No path provided to read file contents from."
+
+    if not os.path.exists(path):
+        return f"File {path} does not exist."
+
+    with open(path, "r") as f:
+        return f.read()
+
+
 tools = [
     {
         "type": "function",
@@ -239,6 +274,42 @@ tools = [
                     },
                 },
                 "required": ["question"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_files_in_dir",
+            "description": "Lists the files in a directory.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "dir": {
+                        "type": "string",
+                        "description": "The directory to list files in.",
+                    },
+                },
+                "required": ["dir"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "read_file_contents",
+            "description": "Reads the contents of a file.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "The path of the file to read contents from.",
+                    },
+                },
+                "required": ["path"],
                 "additionalProperties": False,
             },
         },


### PR DESCRIPTION
This pull request introduces new functionality to the `src/agent/tools.py` file by adding two new methods for file operations: listing files in a directory and reading file contents. These changes enhance the toolset available for file manipulation.

New methods added:

* [`list_files_in_dir`](diffhunk://#diff-e0b516691ff100add4484a056628cf60d1ad3e562e1540f1a63a67d44cf3efb6R180-R214): This method lists the files in a specified directory. It includes error handling for cases where the directory is not provided or does not exist.
* [`read_file_contents`](diffhunk://#diff-e0b516691ff100add4484a056628cf60d1ad3e562e1540f1a63a67d44cf3efb6R180-R214): This method reads and returns the contents of a specified file. It includes error handling for cases where the file path is not provided or the file does not exist.

Tool definitions added:

* Added tool definition for `list_files_in_dir` to the `tools` list, specifying the function name, description, and required parameters.
* Added tool definition for `read_file_contents` to the `tools` list, specifying the function name, description, and required parameters.